### PR TITLE
fix: follow HTTP 3xx redirects manually on auth POST

### DIFF
--- a/custom_components/eaux_marseille/api.py
+++ b/custom_components/eaux_marseille/api.py
@@ -35,6 +35,12 @@ _ACCESS_KEY = "XX_ma2DD-2017-GSEM-PRD!"
 _MAX_RETRIES = 3
 _BACKOFF_BASE = 1.0  # seconds, doubled each attempt (1s, 2s, 4s)
 
+# Maximum number of HTTP redirects we follow manually for a single request.
+# We follow redirects ourselves (instead of relying on aiohttp's default) so
+# that POST bodies are preserved on 307/308 and so we can log the Location
+# header — which is critical for diagnosing portal-side routing changes.
+_MAX_REDIRECTS = 5
+
 _DEFAULT_HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -199,48 +205,93 @@ class EauxDeMarseilleClient:
         last_error: Exception | None = None
         for attempt in range(_MAX_RETRIES):
             try:
-                async with self._session.request(
-                    method, url, headers=headers, timeout=self._timeout, **kwargs
-                ) as response:
-                    content_type = response.headers.get("Content-Type", "<none>")
-                    _LOGGER.debug(
-                        "%s %s → HTTP %d (content-type=%s)",
-                        method, url, response.status, content_type,
-                    )
+                current_method = method
+                current_url = url
+                for redirect_hop in range(_MAX_REDIRECTS + 1):
+                    request_kwargs = dict(kwargs)
+                    # On 303 (See Other) the redirected request must become a
+                    # GET without a body; on 301/302 we follow the historical
+                    # browser convention of also dropping the body. 307/308
+                    # preserve method and body, which is what the portal needs
+                    # for its auth POST.
+                    if redirect_hop > 0 and current_method == "GET":
+                        request_kwargs.pop("json", None)
+                        request_kwargs.pop("data", None)
 
-                    # 4xx: client error, don't retry
-                    if 400 <= response.status < 500:
-                        text = await response.text()
-                        raise EauxDeMarseilleApiError(
-                            f"HTTP {response.status} at {url}: {text[:200]}"
+                    async with self._session.request(
+                        current_method,
+                        current_url,
+                        headers=headers,
+                        timeout=self._timeout,
+                        allow_redirects=False,
+                        **request_kwargs,
+                    ) as response:
+                        content_type = response.headers.get("Content-Type", "<none>")
+                        _LOGGER.debug(
+                            "%s %s → HTTP %d (content-type=%s)",
+                            current_method, current_url, response.status, content_type,
                         )
-                    # 5xx: server error, will retry
-                    if response.status >= 500:
-                        text = await response.text()
-                        raise aiohttp.ClientResponseError(
-                            response.request_info,
-                            response.history,
-                            status=response.status,
-                            message=text[:200],
-                        )
-                    if not expect_json:
-                        return None
 
-                    # Parse JSON with clear error if the body isn't JSON.
-                    # The portal sometimes returns HTML (login redirect, WAF block,
-                    # CDN error page) with a 200 status — detect and report this.
-                    try:
-                        return await response.json(content_type=None)
-                    except (
-                        json.JSONDecodeError,
-                        aiohttp.ContentTypeError,
-                    ) as err:
-                        body = await response.text()
-                        raise EauxDeMarseilleApiError(
-                            f"Expected JSON from {url} but got "
-                            f"content-type={content_type}, status={response.status}. "
-                            f"Body starts with: {body[:200]!r}"
-                        ) from err
+                        # 3xx: follow redirect manually so we preserve the POST
+                        # body on 307/308 and so we can log the Location header.
+                        if 300 <= response.status < 400:
+                            location = response.headers.get("Location")
+                            if not location:
+                                body = await response.text()
+                                raise EauxDeMarseilleApiError(
+                                    f"HTTP {response.status} at {current_url} "
+                                    f"with no Location header. "
+                                    f"Body starts with: {body[:200]!r}"
+                                )
+                            next_url = str(URL(current_url).join(URL(location)))
+                            _LOGGER.info(
+                                "Following HTTP %d redirect: %s → %s",
+                                response.status, current_url, next_url,
+                            )
+                            if redirect_hop >= _MAX_REDIRECTS:
+                                raise EauxDeMarseilleApiError(
+                                    f"Too many redirects ({_MAX_REDIRECTS}) "
+                                    f"starting from {url}; last hop: {next_url}"
+                                )
+                            if response.status in (301, 302, 303) and current_method == "POST":
+                                current_method = "GET"
+                            current_url = next_url
+                            continue
+
+                        # 4xx: client error, don't retry
+                        if 400 <= response.status < 500:
+                            text = await response.text()
+                            raise EauxDeMarseilleApiError(
+                                f"HTTP {response.status} at {current_url}: {text[:200]}"
+                            )
+                        # 5xx: server error, will retry
+                        if response.status >= 500:
+                            text = await response.text()
+                            raise aiohttp.ClientResponseError(
+                                response.request_info,
+                                response.history,
+                                status=response.status,
+                                message=text[:200],
+                            )
+                        if not expect_json:
+                            return None
+
+                        # Parse JSON with clear error if the body isn't JSON.
+                        # The portal sometimes returns HTML (login redirect, WAF block,
+                        # CDN error page) with a 200 status — detect and report this.
+                        try:
+                            return await response.json(content_type=None)
+                        except (
+                            json.JSONDecodeError,
+                            aiohttp.ContentTypeError,
+                        ) as err:
+                            body = await response.text()
+                            raise EauxDeMarseilleApiError(
+                                f"Expected JSON from {current_url} but got "
+                                f"content-type={content_type}, status={response.status}. "
+                                f"Body starts with: {body[:200]!r}"
+                            ) from err
+                    break
             except (asyncio.TimeoutError, aiohttp.ClientError) as err:
                 last_error = err
                 if attempt < _MAX_RETRIES - 1:
@@ -308,7 +359,11 @@ class EauxDeMarseilleClient:
         except EauxDeMarseilleApiError as err:
             raise EauxDeMarseilleAuthError(f"Login failed: {err}") from err
         if not data or "tokenAuthentique" not in data:
-            raise EauxDeMarseilleAuthError("Login returned unexpected response")
+            keys = sorted(data.keys()) if isinstance(data, dict) else type(data).__name__
+            raise EauxDeMarseilleAuthError(
+                f"Login returned unexpected response (missing 'tokenAuthentique'); "
+                f"got fields: {keys}"
+            )
         ael_token: str = data["tokenAuthentique"]
         user_info: dict = data["utilisateurInfo"]
         self._token = ael_token

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -126,6 +126,66 @@ class TestAuthentication:
             with pytest.raises(EauxDeMarseilleAuthError, match="Login failed"):
                 await client.authenticate()
 
+    async def test_authenticate_follows_307_redirect(
+        self, client: EauxDeMarseilleClient
+    ) -> None:
+        """Authentication follows a 307 redirect on the login POST and preserves the body."""
+        redirected_url = f"{_API_BASE}/Utilisateur/authentification/v2"
+        with aioresponses() as m:
+            m.get(_PORTAL_URL + "/", body="<html></html>")
+            m.post(
+                f"{_API_BASE}/Acces/generateToken",
+                payload={"token": "fake-temp-token"},
+            )
+            m.post(
+                f"{_API_BASE}/Utilisateur/authentification",
+                status=307,
+                headers={"Location": redirected_url},
+            )
+            m.post(
+                redirected_url,
+                payload={
+                    "tokenAuthentique": "fake-ael-token",
+                    "utilisateurInfo": {
+                        "identifiant": "user@example.com",
+                        "nom": "Doe",
+                        "prenom": "John",
+                        "email": "user@example.com",
+                        "titre": "M.",
+                        "userWebId": 42,
+                        "meta": {},
+                        "profils": [],
+                    },
+                },
+            )
+            m.get(
+                f"{_API_BASE}/Abonnement/getContratParDefaut/",
+                payload={"numContrat": CONTRACT_ID},
+            )
+
+            await client.authenticate()
+
+    async def test_authenticate_redirect_without_location(
+        self, client: EauxDeMarseilleClient
+    ) -> None:
+        """A 3xx with no Location header surfaces as a clear API error."""
+        with aioresponses() as m:
+            m.get(_PORTAL_URL + "/", body="<html></html>")
+            m.post(
+                f"{_API_BASE}/Acces/generateToken",
+                payload={"token": "fake-temp-token"},
+            )
+            m.post(
+                f"{_API_BASE}/Utilisateur/authentification",
+                status=307,
+                body="redirect without location",
+            )
+
+            with pytest.raises(
+                EauxDeMarseilleAuthError, match="no Location header"
+            ):
+                await client.authenticate()
+
 
 class TestFetch:
     """Test data fetching."""


### PR DESCRIPTION
## Summary

- Le endpoint `POST /webapi/Utilisateur/authentification` du portail renvoie maintenant un **HTTP 307**, qu'aiohttp ne suit pas automatiquement (probablement à cause du `Location`/de la cible jugée non sûre). L'auth échouait alors avec le message opaque *"Login returned unexpected response"*.
- `_request()` suit désormais les redirections manuellement avec `allow_redirects=False` : la méthode et le corps JSON sont préservés sur 307/308 (indispensable pour le POST d'auth), POST est dégradé en GET sur 301/302/303 selon la convention navigateur, l'en-tête `Location` est loggué au niveau INFO pour le diagnostic, et une erreur claire est levée si `Location` manque ou si la chaîne dépasse 5 sauts.
- Le message d'erreur d'auth inclut désormais les clés JSON renvoyées, pour rendre une éventuelle dérive de schéma serveur lisible directement dans le log.

## Test plan

- [x] `pytest tests/test_api.py` — 13 tests passent (dont 2 nouveaux : suivi du 307 préservant le POST + erreur claire si `Location` absent).
- [ ] Vérifier en conditions réelles sur une instance HA que l'auth aboutit, et que la nouvelle ligne de log `Following HTTP 307 redirect: ... → ...` apparaît si le portail redirige.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DT7o89j1Si8MSQNW1PftmJ)_