### PR TITLE
fix: detect daily telemetry from JOURNEE data and sort entries by date

### DIFF
--- a/custom_components/eaux_marseille/api.py
+++ b/custom_components/eaux_marseille/api.py
@@ -97,10 +97,6 @@ class EauxDeMarseilleClient:
             login=login,
             password=password,
         )
-        # Whether the contract exposes daily telemetry (JOURNEE granularity).
-        # Probed lazily on first use and cached for the client's lifetime;
-        # None means "not checked yet".
-        self._daily_available: bool | None = None
 
     async def close(self) -> None:
         """Close the underlying session if we own it."""
@@ -132,36 +128,20 @@ class EauxDeMarseilleClient:
 
     async def fetch_monthly_range(self, year: int) -> list[dict[str, Any]]:
         """Return the raw monthly consumption entries for ``year``."""
-        return await self._with_session_recovery(lambda: self._fetch_chart_inner(year, "MOIS"))
+        return await self._with_session_recovery(lambda: self._chart_entries(year, "MOIS"))
 
     async def fetch_daily_range(self, year: int) -> list[dict[str, Any]]:
         """Return the raw daily consumption entries for ``year``.
 
-        Only meaningful for contracts where :meth:`is_daily_available`
-        returns ``True``; other contracts get the portal's soft 400,
-        which degrades to an empty list.
+        Daily data only exists for contracts whose meter exposes it
+        (communicating meters with JOURNEE granularity enabled).
+        Contracts without it get an empty list — the fetch is tolerant
+        of the portal refusing the endpoint (soft 400, hard 4xx), so it
+        never breaks callers.
         """
-        return await self._with_session_recovery(lambda: self._fetch_chart_inner(year, "JOURNEE"))
-
-    async def is_daily_available(self) -> bool:
-        """Whether the contract exposes daily telemetry (JOURNEE).
-
-        Probes ``/Consommation/isContratTelereve/{contract}`` once and
-        caches the answer for the client's lifetime. Any error during
-        the probe is treated as ``False`` (conservative: fall back to
-        monthly-only behaviour rather than failing the poll).
-        """
-        if self._daily_available is None:
-            try:
-                result = await self._with_session_recovery(
-                    lambda: self._auth.get(f"/Consommation/isContratTelereve/{self._contract_id}")
-                )
-                # The endpoint returns a bare JSON boolean, not an object.
-                self._daily_available = bool(result)
-            except EauxDeMarseilleError as err:
-                _LOGGER.debug("Daily-telemetry probe failed, assuming monthly-only: %s", err)
-                self._daily_available = False
-        return self._daily_available
+        return await self._with_session_recovery(
+            lambda: self._chart_entries(year, "JOURNEE", optional=True)
+        )
 
     async def _fetch_inner(self) -> ConsumptionData:
         last = await self._safe_get(
@@ -172,15 +152,45 @@ class EauxDeMarseilleClient:
         history = await self._safe_get(
             f"/Facturation/listeConsommationsFacturees/{self._contract_id}"
         )
-        # Contracts with daily telemetry carry a fresher meter index in
-        # the JOURNEE series (typically D-1) than the monthly chart.
-        daily: dict[str, Any] = {}
-        if await self.is_daily_available():
-            daily = await self._safe_get(self._chart_path(year, "JOURNEE"))
-        return ConsumptionData.from_api_responses(last, monthly, history, daily=daily)
+        # Always attempt the daily series: when the contract exposes it
+        # (communicating meter) its latest entry carries a fresher index
+        # (D-1) than the monthly chart. Tolerant — contracts without
+        # daily data just get an empty list. No upfront probe needed: the
+        # mere presence of entries tells us whether the meter is daily.
+        daily_entries = await self._chart_entries(year, "JOURNEE", optional=True)
+        return ConsumptionData.from_api_responses(
+            last, monthly, history, daily_entries=daily_entries
+        )
 
-    async def _fetch_chart_inner(self, year: int, granularity: str) -> list[dict[str, Any]]:
-        data = await self._safe_get(self._chart_path(year, granularity))
+    async def _chart_entries(
+        self, year: int, granularity: str, *, optional: bool = False
+    ) -> list[dict[str, Any]]:
+        """Return the ``consommations`` list for a chart granularity.
+
+        For a required series (monthly) this goes through
+        :meth:`_safe_get`, which tolerates the portal's soft 400 ("no
+        data yet" on a fresh contract) and logs it at INFO.
+
+        For an ``optional=True`` series (the daily JOURNEE chart, which
+        most contracts don't expose), any API error other than a session
+        expiry is swallowed at DEBUG and an empty list returned — a
+        monthly-only contract gets that 400 on *every* poll, so it's the
+        normal case, not an anomaly worth an INFO line each time. Session
+        expiries are re-raised so :meth:`_with_session_recovery` can
+        re-authenticate and retry.
+        """
+        path = self._chart_path(year, granularity)
+        if not optional:
+            data = await self._safe_get(path)
+            required: list[dict[str, Any]] = data.get("consommations", [])
+            return required
+        try:
+            data = await self._auth.get(path)
+        except EauxDeMarseilleSessionExpiredError:
+            raise
+        except EauxDeMarseilleApiError as err:
+            _LOGGER.debug("Optional %s series unavailable: %s", granularity, err)
+            return []
         entries: list[dict[str, Any]] = data.get("consommations", [])
         return entries
 

--- a/custom_components/eaux_marseille/manifest.json
+++ b/custom_components/eaux_marseille/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.eaux_marseille"],
   "quality_scale": "gold",
   "requirements": ["tenacity>=8.0"],
-  "version": "1.16.0"
+  "version": "1.16.1"
 }

--- a/custom_components/eaux_marseille/models.py
+++ b/custom_components/eaux_marseille/models.py
@@ -44,7 +44,7 @@ class ConsumptionData:
         last_billed: dict[str, Any],
         monthly: dict[str, Any],
         history: dict[str, Any],
-        daily: dict[str, Any] | None = None,
+        daily_entries: list[dict[str, Any]] | None = None,
     ) -> ConsumptionData:
         """Build a :class:`ConsumptionData` from the endpoint payloads.
 
@@ -58,24 +58,27 @@ class ConsumptionData:
             ``/Consommation/listeConsommationsInstanceAlerteChart/.../MOIS/true``.
         :param history: Payload from
             ``/Facturation/listeConsommationsFacturees/{contract}``.
-        :param daily: Optional payload from the same chart endpoint with
-            ``JOURNEE`` granularity — only available on contracts with
-            daily telemetry. When present, its latest entry carries a
-            fresher meter index (typically D-1) than the monthly chart,
-            and is preferred for :attr:`index_precise_m3`.
+        :param daily_entries: Optional ``consommations`` list from the same
+            chart endpoint with ``JOURNEE`` granularity — only present on
+            contracts with daily telemetry. Its most recent entry carries a
+            fresher meter index (typically D-1) than the monthly chart, so
+            it is preferred for :attr:`index_precise_m3`. The portal serves
+            this series newest-first, hence the explicit max-by-date below
+            instead of relying on list position.
         """
         readings = history.get("resultats", [])
         previous = readings[1] if len(readings) > 1 else {}
 
         monthly_entries = monthly.get("consommations", [])
+        # The monthly chart comes back chronological, so the last entry is
+        # the current month.
         current_month = monthly_entries[-1] if monthly_entries else {}
         year_total = round(
             sum(entry.get("volumeConsoEnM3", 0.0) for entry in monthly_entries),
             3,
         )
 
-        daily_entries = (daily or {}).get("consommations", [])
-        latest_daily = daily_entries[-1] if daily_entries else {}
+        latest_daily = _latest_by_date(daily_entries or [])
         index_precise = _litres_to_m3(latest_daily.get("valeurIndex"))
         if index_precise is None:
             index_precise = _litres_to_m3(current_month.get("valeurIndex"))
@@ -100,6 +103,19 @@ class ConsumptionData:
 def _iso_date_prefix(value: str | None) -> str | None:
     """Return the ``YYYY-MM-DD`` prefix of an ISO datetime, or ``None``."""
     return value[:10] if value else None
+
+
+def _latest_by_date(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return the entry with the most recent ``dateReleve``, or ``{}``.
+
+    Used for the daily (``JOURNEE``) series, which the portal serves
+    newest-first — so the freshest reading is *not* the last list item.
+    ISO 8601 strings with a fixed UTC offset sort lexicographically,
+    which is all we need to find the newest day.
+    """
+    if not entries:
+        return {}
+    return max(entries, key=lambda entry: entry.get("dateReleve", ""))
 
 
 def _litres_to_m3(litres: float | int | None) -> float | None:

--- a/custom_components/eaux_marseille/statistics.py
+++ b/custom_components/eaux_marseille/statistics.py
@@ -87,29 +87,30 @@ async def async_import_historical_statistics(
                 contract_id,
             )
 
-        # Contracts with daily telemetry (JOURNEE granularity) also get a
-        # daily statistic. Other contracts skip this entirely — the probe
-        # is cached on the client so this costs one extra GET, once.
-        if await client.is_daily_available():
-            daily_stats = await _collect_series(client.fetch_daily_range)
-            if daily_stats:
-                statistic_id = f"{DOMAIN}:daily_consumption_{contract_id}"
-                async_add_external_statistics(
-                    hass,
-                    _build_metadata(contract_id, statistic_id, "Daily consumption"),
-                    daily_stats,
-                )
-                _LOGGER.info(
-                    "Imported %d daily statistics for contract %s (total sum: %s m³)",
-                    len(daily_stats),
-                    contract_id,
-                    daily_stats[-1]["sum"],
-                )
-            else:
-                _LOGGER.debug(
-                    "Daily telemetry available but no daily entries for contract %s",
-                    contract_id,
-                )
+        # Contracts whose meter exposes daily telemetry (JOURNEE
+        # granularity) also get a daily statistic. There's no upfront
+        # probe: ``fetch_daily_range`` is tolerant and returns an empty
+        # list for contracts without it, so a monthly-only contract just
+        # yields no daily series and we skip the import.
+        daily_stats = await _collect_series(client.fetch_daily_range)
+        if daily_stats:
+            statistic_id = f"{DOMAIN}:daily_consumption_{contract_id}"
+            async_add_external_statistics(
+                hass,
+                _build_metadata(contract_id, statistic_id, "Daily consumption"),
+                daily_stats,
+            )
+            _LOGGER.info(
+                "Imported %d daily statistics for contract %s (total sum: %s m³)",
+                len(daily_stats),
+                contract_id,
+                daily_stats[-1]["sum"],
+            )
+        else:
+            _LOGGER.debug(
+                "No daily telemetry to import for contract %s",
+                contract_id,
+            )
     except Exception:
         _LOGGER.exception("Error during historical statistics import")
         ir.async_create_issue(
@@ -137,6 +138,12 @@ async def _collect_series(
     over the full series every time, so overwriting the recorder points
     yields an internally consistent set whatever the portal has revised
     since the last run.
+
+    Entries are sorted chronologically before accumulating: the portal
+    serves the JOURNEE series newest-first, and feeding that order into a
+    running sum would assign the largest sum to the earliest day, leaving
+    a statistic whose cumulative total decreases over time (it would read
+    as empty/broken in the Energy dashboard).
     """
     stats: list[StatisticData] = []
     running_sum = 0.0
@@ -150,7 +157,7 @@ async def _collect_series(
             continue
         _LOGGER.debug("Year %d: fetched %d entries", year, len(entries))
 
-        for entry in entries:
+        for entry in sorted(entries, key=lambda e: e.get("dateReleve", "")):
             stat = _entry_to_stat(entry, running_sum)
             if stat is None:
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,6 @@ def mock_client() -> MagicMock:
     client.fetch = AsyncMock(return_value=MOCK_CONSUMPTION)
     client.fetch_monthly_range = AsyncMock(return_value=MOCK_MONTHLY_ENTRIES)
     client.fetch_daily_range = AsyncMock(return_value=[])
-    client.is_daily_available = AsyncMock(return_value=False)
     client.close = AsyncMock(return_value=None)
     return client
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,11 +96,6 @@ def mock_auth() -> aioresponses:
             f"{_API_BASE}/Abonnement/getContratParDefaut/",
             payload={"numContrat": CONTRACT_ID},
         )
-        # Daily-telemetry probe: default to a monthly-only contract.
-        m.get(
-            f"{_API_BASE}/Consommation/isContratTelereve/{CONTRACT_ID}",
-            payload=False,
-        )
         yield m
 
 
@@ -416,13 +411,18 @@ class TestFetch:
             },
         )
         mock_auth.get(
-            re.compile(r".*listeConsommationsInstanceAlerteChart.*"),
+            re.compile(r".*listeConsommationsInstanceAlerteChart.*/MOIS/true"),
             payload={
                 "consommations": [
                     {"volumeConsoEnM3": 5.0, "valeurIndex": 207501},
                     {"volumeConsoEnM3": 5.481, "valeurIndex": 212982},
                 ]
             },
+        )
+        # Monthly-only contract: the daily series is unauthorised (soft 400).
+        mock_auth.get(
+            re.compile(r".*listeConsommationsInstanceAlerteChart.*/JOURNEE/true"),
+            payload={"consommations": []},
         )
         mock_auth.get(
             f"{_API_BASE}/Facturation/listeConsommationsFacturees/{CONTRACT_ID}",
@@ -440,8 +440,8 @@ class TestFetch:
 
         assert isinstance(data, ConsumptionData)
         assert data.index_m3 == 193.0
-        # Precise index comes from the LAST monthly entry's valeurIndex
-        # (in litres) converted to m³: 212982 L -> 212.982 m³.
+        # No daily series, so the precise index falls back to the LAST
+        # monthly entry's valeurIndex (litres -> m³): 212982 L -> 212.982 m³.
         assert data.index_precise_m3 == 212.982
         assert data.last_reading_m3 == 18.0
         assert data.last_reading_litres == 18000
@@ -495,6 +495,7 @@ class TestFreshContract:
             status=400,
             body=self._SOFT_400_BODY,
             content_type="application/json",
+            repeat=True,
         )
         mock_auth.get(
             f"{_API_BASE}/Facturation/listeConsommationsFacturees/{CONTRACT_ID}",
@@ -535,6 +536,7 @@ class TestFreshContract:
             status=400,
             body=self._SOFT_400_BODY,
             content_type="application/json",
+            repeat=True,
         )
 
         await client.authenticate()
@@ -606,100 +608,59 @@ class TestDailyTelemetry:
         )
 
     async def test_daily_index_preferred_when_available(
-        self, client: EauxDeMarseilleClient
+        self, client: EauxDeMarseilleClient, mock_auth: aioresponses
     ) -> None:
-        """When the probe says daily is available, index_precise comes from
-        the freshest JOURNEE entry instead of the monthly chart."""
-        with aioresponses() as m:
-            m.get(_PORTAL_URL + "/", body="<html></html>")
-            m.post(
-                f"{_API_BASE}/Acces/generateToken",
-                payload={"token": "fake-temp-token"},
-            )
-            m.post(
-                f"{_API_BASE}/Utilisateur/authentification",
-                payload={
-                    "tokenAuthentique": "fake-ael-token",
-                    "utilisateurInfo": {"identifiant": "user@example.com"},
-                },
-            )
-            m.get(
-                f"{_API_BASE}/Abonnement/getContratParDefaut/",
-                payload={"numContrat": CONTRACT_ID},
-            )
-            self._register_data_endpoints(m)
-            m.get(
-                f"{_API_BASE}/Consommation/isContratTelereve/{CONTRACT_ID}",
-                payload=True,
-            )
-            # Daily series: latest entry is fresher (213105 L) than monthly.
-            m.get(
-                re.compile(r".*listeConsommationsInstanceAlerteChart.*/JOURNEE/true"),
-                payload={
-                    "consommations": [
-                        {"volumeConsoEnM3": 0.2, "valeurIndex": 212900},
-                        {"volumeConsoEnM3": 0.205, "valeurIndex": 213105},
-                    ]
-                },
-            )
+        """When the JOURNEE series carries data, index_precise comes from
+        its freshest entry instead of the monthly chart.
 
-            data = await client.fetch()
+        The portal serves the daily series newest-first, so the freshest
+        reading (213105 L, dated latest) is the *first* list item — the
+        client must pick by date, not by position.
+        """
+        self._register_data_endpoints(mock_auth)
+        mock_auth.get(
+            re.compile(r".*listeConsommationsInstanceAlerteChart.*/JOURNEE/true"),
+            payload={
+                "consommations": [
+                    {"dateReleve": "2026-06-14T00:00:00+02:00", "valeurIndex": 213105},
+                    {"dateReleve": "2026-06-13T00:00:00+02:00", "valeurIndex": 212900},
+                ]
+            },
+        )
+
+        data = await client.fetch()
 
         assert data.index_precise_m3 == 213.105
 
-    async def test_monthly_only_contract_skips_daily(
+    async def test_monthly_only_contract_falls_back_to_monthly_index(
         self, client: EauxDeMarseilleClient, mock_auth: aioresponses
     ) -> None:
-        """Probe returns False (mock_auth default): no JOURNEE call is
-        made, index_precise falls back to the monthly chart value."""
+        """A contract without daily data (soft 400 on JOURNEE) keeps
+        working: index_precise falls back to the monthly chart value."""
         self._register_data_endpoints(mock_auth)
-        # Note: no JOURNEE mock registered. If the client called it anyway,
-        # aioresponses would raise on the unmatched request.
+        mock_auth.get(
+            re.compile(r".*listeConsommationsInstanceAlerteChart.*/JOURNEE/true"),
+            status=400,
+            body=TestFreshContract._SOFT_400_BODY,
+            content_type="application/json",
+        )
         data = await client.fetch()
         assert data.index_precise_m3 == 212.982
 
-    async def test_probe_is_cached_across_fetches(
+    async def test_daily_hard_400_is_tolerated(
         self, client: EauxDeMarseilleClient, mock_auth: aioresponses
     ) -> None:
-        """The telereve probe runs once; later fetches reuse the answer.
-
-        mock_auth registers the probe exactly once (non-repeating): a
-        second probe call would hit an unmatched URL and raise.
-        """
-        self._register_data_endpoints(mock_auth, repeat=True)
-        await client.fetch()
-        await client.fetch()
-
-    async def test_probe_error_defaults_to_monthly_only(
-        self, client: EauxDeMarseilleClient
-    ) -> None:
-        """A failing probe (404) degrades to monthly-only, not a crash."""
-        with aioresponses() as m:
-            m.get(_PORTAL_URL + "/", body="<html></html>")
-            m.post(
-                f"{_API_BASE}/Acces/generateToken",
-                payload={"token": "fake-temp-token"},
-            )
-            m.post(
-                f"{_API_BASE}/Utilisateur/authentification",
-                payload={
-                    "tokenAuthentique": "fake-ael-token",
-                    "utilisateurInfo": {"identifiant": "user@example.com"},
-                },
-            )
-            m.get(
-                f"{_API_BASE}/Abonnement/getContratParDefaut/",
-                payload={"numContrat": CONTRACT_ID},
-            )
-            self._register_data_endpoints(m)
-            m.get(
-                f"{_API_BASE}/Consommation/isContratTelereve/{CONTRACT_ID}",
-                status=404,
-            )
-
-            data = await client.fetch()
-
-        # Fallback to the monthly index; no exception raised.
+        """A hard 400 on the JOURNEE endpoint (unauthorised, not the soft
+        'no data' marker) must not break the poll — the daily series is
+        optional, so it degrades to the monthly index."""
+        self._register_data_endpoints(mock_auth)
+        mock_auth.get(
+            re.compile(r".*listeConsommationsInstanceAlerteChart.*/JOURNEE/true"),
+            status=400,
+            body='{"severity": "Error", "message": "not authorised"}',
+            content_type="application/json",
+        )
+        data = await client.fetch()
         assert data.index_precise_m3 == 212.982
 
     async def test_fetch_daily_range_returns_entries(
@@ -718,6 +679,21 @@ class TestDailyTelemetry:
         entries = await client.fetch_daily_range(2026)
         assert len(entries) == 1
         assert entries[0]["volumeConsoEnM3"] == 0.2
+
+    async def test_fetch_daily_range_tolerates_unauthorized(
+        self, client: EauxDeMarseilleClient, mock_auth: aioresponses
+    ) -> None:
+        """fetch_daily_range returns [] when the contract has no daily
+        telemetry (hard 400), rather than propagating the error."""
+        mock_auth.get(
+            re.compile(r".*listeConsommationsInstanceAlerteChart.*/JOURNEE/true"),
+            status=400,
+            body='{"severity": "Error", "message": "not authorised"}',
+            content_type="application/json",
+        )
+        await client.authenticate()
+        entries = await client.fetch_daily_range(2026)
+        assert entries == []
 
 
 class TestSessionRecovery:
@@ -782,6 +758,7 @@ class TestSessionRecovery:
             m.get(
                 re.compile(r".*listeConsommationsInstanceAlerteChart.*"),
                 payload={"consommations": []},
+                repeat=True,
             )
             m.get(
                 f"{_API_BASE}/Facturation/listeConsommationsFacturees/{CONTRACT_ID}",
@@ -808,6 +785,7 @@ class TestSessionRecovery:
             m.get(
                 re.compile(r".*listeConsommationsInstanceAlerteChart.*"),
                 payload={"consommations": []},
+                repeat=True,
             )
             m.get(
                 f"{_API_BASE}/Facturation/listeConsommationsFacturees/{CONTRACT_ID}",
@@ -854,11 +832,7 @@ class TestSessionRecovery:
 
 
 def _register_auth_flow(m: aioresponses) -> None:
-    """Register the four endpoints of one full auth flow (+ daily probe)."""
-    m.get(
-        f"{_API_BASE}/Consommation/isContratTelereve/{CONTRACT_ID}",
-        payload=False,
-    )
+    """Register the four endpoints of one full auth flow."""
     m.get(_PORTAL_URL + "/", body="<html></html>")
     m.post(
         f"{_API_BASE}/Acces/generateToken",

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -164,14 +164,19 @@ async def test_daily_statistic_imported_when_telemetry_available(
     mock_recorder,
     mock_add_external_stats,
 ) -> None:
-    """Contracts with daily telemetry also get a daily statistic (#29)."""
-    mock_client.is_daily_available.return_value = True
+    """Contracts with daily telemetry also get a daily statistic (#29).
+
+    No probe: a non-empty ``fetch_daily_range`` is enough to trigger the
+    daily import. The entries arrive newest-first (as the portal serves
+    them); the importer must sort them so the cumulative sum increases
+    with time.
+    """
     mock_client.fetch_monthly_range.side_effect = _only_year(2024, MOCK_MONTHLY_ENTRIES)
     mock_client.fetch_daily_range.side_effect = _only_year(
         2024,
         [
-            {"dateReleve": "2024-07-15T00:00:00+02:00", "volumeConsoEnM3": 0.2},
             {"dateReleve": "2024-07-16T00:00:00+02:00", "volumeConsoEnM3": 0.3},
+            {"dateReleve": "2024-07-15T00:00:00+02:00", "volumeConsoEnM3": 0.2},
         ],
     )
 
@@ -183,6 +188,8 @@ async def test_daily_statistic_imported_when_telemetry_available(
     daily_stats = mock_add_external_stats.call_args_list[1].args[2]
     assert daily_metadata["statistic_id"] == f"{DOMAIN}:daily_consumption_{MOCK_CONTRACT_ID}"
     assert "Daily consumption" in daily_metadata["name"]
+    # Sorted chronologically despite the newest-first input, so the
+    # cumulative sum rises 0.2 -> 0.5 (15th then 16th).
     assert len(daily_stats) == 2
     assert daily_stats[0]["sum"] == 0.2
     assert daily_stats[1]["sum"] == 0.5
@@ -194,14 +201,18 @@ async def test_no_daily_statistic_for_monthly_only_contract(
     mock_recorder,
     mock_add_external_stats,
 ) -> None:
-    """Monthly-only contracts (probe False) get exactly one import."""
-    mock_client.is_daily_available.return_value = False
+    """Monthly-only contracts get exactly one import (no daily series).
+
+    ``fetch_daily_range`` is always called now, but returns an empty list
+    for contracts without daily telemetry, so no daily statistic lands.
+    """
     mock_client.fetch_monthly_range.side_effect = _only_year(2024, MOCK_MONTHLY_ENTRIES)
+    mock_client.fetch_daily_range.return_value = []
 
     await async_import_historical_statistics(hass, mock_client, MOCK_CONTRACT_ID)
 
     assert mock_add_external_stats.call_count == 1
-    mock_client.fetch_daily_range.assert_not_called()
+    mock_client.fetch_daily_range.assert_called()
 
 
 async def test_import_skips_entries_without_date(


### PR DESCRIPTION
## Problème

La fonctionnalité de télémétrie journalière (v1.16.0) ne fonctionnait pas pour les compteurs communicants. Retour de terrain (Vivaigo, compteur communicant) sur la 1.16.0 :

- aucun appel à `/JOURNEE`,
- pas de statistique `eaux_marseille:daily_consumption_…`,
- index « précis » figé sur la valeur mensuelle (J-1 manquant).

### Cause racine — 2 bugs

1. **Mauvais détecteur.** Le fetch JOURNEE était conditionné à la sonde `isContratTelereve`, qui renvoie `false` même pour un contrat qui expose bien des données journalières. Conséquence : la série journalière n'était jamais récupérée.

2. **Ordre des entrées.** Le portail sert la série `JOURNEE` du **plus récent au plus ancien**. L'import accumulait le `sum` dans l'ordre du tableau → la somme cumulée la plus élevée se retrouvait sur le jour le plus ancien (statistique dont le total décroît dans le temps, inutilisable côté Énergie), et l'index précis était lu sur l'entrée la plus vieille.

## Correctif

- **Suppression de la sonde `isContratTelereve`** (et de son cache). La série journalière est désormais **toujours tentée** et utilisée dès qu'elle renvoie des données. Les contrats sans journalier reçoivent le `400` du portail (soft ou hard), qui est toléré et bascule proprement en mono-mensuel. Le fetch optionnel logge en `debug` : un contrat mono-mensuel n'émet plus une ligne `INFO` à chaque poll.
- **Tri chronologique** des entrées avant le calcul des cumuls, et sélection de l'index précis par **date la plus récente** plutôt que par position.

## Validation

- Local : ruff, ruff format, mypy strict, pytest (`test_api.py` 45 passed ; suite complète 48 passed / 29 skipped HA-only).
- Smoke test sur contrat **mono-mensuel (SEM)** : poll `success: True`, 26 statistiques mensuelles importées, `JOURNEE 400` toléré, aucune statistique journalière parasite, zéro erreur. Confirme que le portail renvoie un **soft-400** (et non un 403) sur un contrat sans journalier — donc pas de boucle de re-authentification.

Refs #29.
