### PR TITLE
fix: deduplicate statistics entries by date to avoid year-boundary double-count

### DIFF
--- a/custom_components/eaux_marseille/manifest.json
+++ b/custom_components/eaux_marseille/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.eaux_marseille"],
   "quality_scale": "gold",
   "requirements": ["tenacity>=8.0"],
-  "version": "1.16.1"
+  "version": "1.16.2"
 }

--- a/custom_components/eaux_marseille/statistics.py
+++ b/custom_components/eaux_marseille/statistics.py
@@ -139,14 +139,20 @@ async def _collect_series(
     yields an internally consistent set whatever the portal has revised
     since the last run.
 
-    Entries are sorted chronologically before accumulating: the portal
-    serves the JOURNEE series newest-first, and feeding that order into a
-    running sum would assign the largest sum to the earliest day, leaving
-    a statistic whose cumulative total decreases over time (it would read
-    as empty/broken in the Energy dashboard).
+    Entries are deduplicated by reading date and then accumulated in
+    chronological order. Two reasons:
+
+    * The portal serves the JOURNEE series newest-first; feeding that
+      order into a running sum would assign the largest sum to the
+      earliest day, leaving a statistic whose cumulative total decreases
+      over time (it reads as empty/broken in the Energy dashboard).
+    * A year's query window can return a boundary day that also belongs
+      to the adjacent year — a ``dateReleve`` like
+      ``2026-01-01T00:00:00+02:00`` (22:00 UTC the previous day) falls
+      inside the prior year's UTC window. Without dedup that day is
+      counted in both yearly fetches and inflates the cumulative total.
     """
-    stats: list[StatisticData] = []
-    running_sum = 0.0
+    by_date: dict[str, dict[str, Any]] = {}
     current_year = datetime.now(UTC).year
 
     for year in range(_START_YEAR, current_year + 1):
@@ -157,12 +163,19 @@ async def _collect_series(
             continue
         _LOGGER.debug("Year %d: fetched %d entries", year, len(entries))
 
-        for entry in sorted(entries, key=lambda e: e.get("dateReleve", "")):
-            stat = _entry_to_stat(entry, running_sum)
-            if stat is None:
-                continue
-            running_sum = stat["sum"]
-            stats.append(stat)
+        for entry in entries:
+            date = entry.get("dateReleve", "")
+            if date:
+                by_date[date] = entry
+
+    stats: list[StatisticData] = []
+    running_sum = 0.0
+    for date in sorted(by_date):
+        stat = _entry_to_stat(by_date[date], running_sum)
+        if stat is None:
+            continue
+        running_sum = stat["sum"]
+        stats.append(stat)
 
     return stats
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -215,6 +215,44 @@ async def test_no_daily_statistic_for_monthly_only_contract(
     mock_client.fetch_daily_range.assert_called()
 
 
+async def test_import_dedupes_year_boundary_day(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    mock_recorder,
+    mock_add_external_stats,
+) -> None:
+    """A day returned by two adjacent yearly windows is counted once.
+
+    The portal's UTC year window can return a Jan-1 reading (whose
+    +02:00 dateReleve is 22:00 UTC on Dec 31) in both years. Without
+    dedup the boundary day would be summed twice and inflate the total.
+    """
+    boundary = {"dateReleve": "2026-01-01T00:00:00+02:00", "volumeConsoEnM3": 1.0}
+
+    def _side_effect(year: int):
+        if year == 2025:
+            return [
+                {"dateReleve": "2025-12-31T00:00:00+01:00", "volumeConsoEnM3": 2.0},
+                boundary,
+            ]
+        if year == 2026:
+            return [
+                boundary,
+                {"dateReleve": "2026-01-02T00:00:00+01:00", "volumeConsoEnM3": 3.0},
+            ]
+        return []
+
+    mock_client.fetch_monthly_range.side_effect = _side_effect
+
+    await async_import_historical_statistics(hass, mock_client, MOCK_CONTRACT_ID)
+
+    stats = mock_add_external_stats.call_args.args[2]
+    # Three distinct days (31/12, 01/01, 02/01); the boundary day counts once.
+    assert len(stats) == 3
+    assert [s["state"] for s in stats] == [2.0, 1.0, 3.0]
+    assert [s["sum"] for s in stats] == [2.0, 3.0, 6.0]
+
+
 async def test_import_skips_entries_without_date(
     hass: HomeAssistant,
     mock_client: MagicMock,


### PR DESCRIPTION
## Problème

Sur un compteur communicant, le cumul de la statistique journalière dépassait légèrement l'index absolu du compteur — alors qu'il manque pourtant une année entière de données journalières (2024). Symptôme remonté sur le forum :

- Index compteur (précis) = 95.307 m³ (relevé absolu)
- Daily statistics SUM = 95.674 m³ (> index, ce qui est anormal)

### Cause

`_collect_series` récupérait la série une année à la fois et accumulait chaque année indépendamment. La fenêtre de requête annuelle est calculée en **UTC**, mais les entrées portent un offset local (`+02:00`/`+01:00`). Une journée de bordure comme `2026-01-01T00:00:00+02:00` (= 31/12 22:00 UTC) tombe donc **dans la fenêtre UTC de l'année précédente** et peut être renvoyée par deux récupérations annuelles consécutives. Ce jour-là était alors compté **deux fois** dans le cumul.

(Le mensuel n'est pas affecté : les mois sont distincts d'une année à l'autre. Seul le journalier, beaucoup plus dense, exhibe le doublon.)

## Correctif

Collecter les entrées dans une **map indexée par `dateReleve`** sur toutes les années avant d'accumuler, de sorte que chaque date de relevé ne contribue qu'une seule fois. L'ordre chronologique est préservé (tri par date avant le calcul du cumul), donc le correctif newest-first introduit en v1.16.1 reste en place.

## Tests

- Nouveau test `test_import_dedupes_year_boundary_day` : une journée renvoyée par deux fenêtres annuelles n'est comptée qu'une fois.
- Local : ruff, ruff format, mypy strict, `pytest test_api.py` (45 passed). Les tests `statistics` (HA-only, dont le nouveau) tournent en CI.

Refs #29.