### PR TITLE
fix: set unit_class on external statistics so the Energy water picker lists them

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -56,6 +56,8 @@ Une **statistique externe mensuelle** est également importée sous l'identifian
 
 Les contrats dont le compteur expose la **télérelève journalière** (compteurs communicants avec la granularité `JOURNEE` activée sur le portail) bénéficient en plus d'une **statistique externe journalière** sous `eaux_marseille:daily_consumption_<contrat>`, et le capteur d'index précis est alimenté par la série journalière (à jour à J-1 en général). La détection est automatique ; les contrats en relevé trimestriel conservent le comportement mensuel actuel.
 
+> **Statistiques externes vs entités.** Les identifiants `eaux_marseille:…` ci-dessus (avec le `:`) sont des *statistiques externes*, pas des entités. Elles apparaissent dans les sélecteurs de **statistiques** — la source d'eau du tableau de bord Énergie et la carte `statistics-graph` — mais **pas** dans le sélecteur d'*entités* classique proposé à l'ajout de la plupart des cartes, ni dans l'onglet Historique. Pour les afficher depuis l'interface, utilisez une carte `statistics-graph` (son sélecteur liste les statistiques) ou collez l'identifiant en YAML. Si une carte demande une *entité*, utilisez plutôt une des lignes `sensor.…` — en particulier `…_index_compteur_precis`, un capteur d'eau `total_increasing` qui fait aussi directement office de source d'eau pour le tableau de bord Énergie.
+
 ## Cas d'usage
 
 ### Suivre l'eau dans le tableau de bord Énergie

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ A **monthly external statistic** is also imported under the ID `eaux_marseille:m
 
 Contracts whose meter exposes **daily telemetry** (communicating meters with the `JOURNEE` granularity enabled on the portal) additionally get a **daily external statistic** under `eaux_marseille:daily_consumption_<contract>`, and the precise meter index sensor is fed from the daily series (typically up to date as of yesterday). Detection is automatic; quarterly-read contracts keep the monthly-only behaviour.
 
+> **External statistics vs. entities.** The `eaux_marseille:…` IDs above (note the colon) are *external statistics*, not entities. They appear in **statistic** pickers — the Energy dashboard's water source and the `statistics-graph` card — but **not** in the generic *entity* picker you get when adding most cards, and not in the History tab. To chart them from the UI, use a `statistics-graph` card (its picker lists statistics) or paste the ID in YAML. If a card asks for an *entity*, use one of the `sensor.…` rows instead — in particular `…_index_compteur_precis`, a `total_increasing` water sensor that also works directly as an Energy water source.
+
 ## Use cases
 
 ### Track water on the Energy dashboard

--- a/custom_components/eaux_marseille/manifest.json
+++ b/custom_components/eaux_marseille/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.eaux_marseille"],
   "quality_scale": "gold",
   "requirements": ["tenacity>=8.0"],
-  "version": "1.16.2"
+  "version": "1.16.3"
 }

--- a/custom_components/eaux_marseille/statistics.py
+++ b/custom_components/eaux_marseille/statistics.py
@@ -215,8 +215,18 @@ def _build_metadata(contract_id: str, statistic_id: str, label: str) -> Statisti
     ``mean_type=StatisticMeanType.NONE`` is the canonical replacement for
     the legacy ``has_mean=False`` flag (which HA core deprecated and
     removed in 2026.4). Water consumption is a counter, so no mean is
-    recorded. ``unit_class=None`` lets HA derive the unit class from
-    ``unit_of_measurement``.
+    recorded.
+
+    ``unit_class`` must be set explicitly to the volume class. The
+    recorder does not derive it for external statistics, and the Energy
+    dashboard's water source picker filters strictly on
+    ``unit_class == "volume"`` (the statistics-graph card's picker does
+    too) — leaving it ``None`` makes the statistic invisible in both, even
+    though its unit is m³. Entity-backed water statistics get ``"volume"``
+    automatically; we mirror that. The literal matches
+    ``homeassistant.util.unit_conversion.VolumeConverter.UNIT_CLASS`` (not
+    imported, to keep this module loadable under the lightweight test
+    stubs).
     """
     metadata: StatisticMetaData = {
         "mean_type": StatisticMeanType.NONE,
@@ -224,7 +234,7 @@ def _build_metadata(contract_id: str, statistic_id: str, label: str) -> Statisti
         "name": f"Eaux de Marseille {contract_id} — {label}",
         "source": DOMAIN,
         "statistic_id": statistic_id,
-        "unit_class": None,
+        "unit_class": "volume",
         "unit_of_measurement": UnitOfVolume.CUBIC_METERS,
     }
     return metadata

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -79,6 +79,10 @@ async def test_import_creates_statistics(
     assert metadata["source"] == DOMAIN
     assert metadata["statistic_id"] == f"{DOMAIN}:monthly_consumption_{MOCK_CONTRACT_ID}"
     assert metadata["has_sum"] is True
+    # unit_class must be the volume class, not None: the Energy dashboard
+    # water picker and the statistics-graph picker both filter strictly on
+    # unit_class == "volume" and would otherwise hide the statistic (#29).
+    assert metadata["unit_class"] == "volume"
     # has_mean=False was deprecated and removed in HA 2026.4 in favour of
     # the typed StatisticMeanType.NONE (see issue #19).
     assert metadata["mean_type"] == StatisticMeanType.NONE


### PR DESCRIPTION
## Problème

Les statistiques externes (`eaux_marseille:monthly_consumption_…` / `:daily_consumption_…`) n'apparaissaient ni dans le sélecteur de la **source d'eau du tableau de bord Énergie**, ni dans le sélecteur de la carte **statistics-graph**. On ne pouvait les exploiter qu'en écrivant l'identifiant à la main en YAML. Remonté par un utilisateur sur le forum.

### Cause

Ces statistiques étaient créées avec `unit_class=None`. Le recorder **ne dérive pas** `unit_class` pour les statistiques externes — la colonne restait donc `NULL` dans `statistics_meta` (vérifié en base sur une install réelle). Or le picker « Eau » du dashboard Énergie (et celui de la carte statistics-graph) filtrent en strict sur `unit_class == "volume"` :

```
statisticIds = statisticIds.filter((meta) => includeUnitClasses.includes(meta.unit_class));
```

`null` n'est pas dans `["volume"]` → la statistique est masquée, alors même que son unité est `m³`. (Le filtre `device_class` est, lui, contourné pour les statistiques externes sans entité, donc ce n'était pas le blocage.)

### Vérifié en base

Tous les capteurs eau (recorder) portent `unit_class='volume'` ; seules nos 2 lignes externes avaient `unit_class=NULL`.

## Correctif

`_build_metadata` pose désormais `unit_class="volume"` (la valeur que `VolumeConverter.UNIT_CLASS` produit, et que les statistiques d'entités eau obtiennent automatiquement). Les métadonnées étant ré-écrites (upsert) à chaque import, les installations existantes sont corrigées au prochain passage du timer journalier ou via `reimport_statistics`.

> Note : on n'importe pas `VolumeConverter` (le module `homeassistant.util.unit_conversion` n'existe pas sous les stubs de test légers) — on utilise le littéral `"volume"`, documenté dans le code.

## Doc

Ajout dans les deux READMEs d'une note **statistiques externes vs entités** : les `eaux_marseille:…` apparaissent dans les sélecteurs de *statistiques* (source Énergie, carte statistics-graph), pas dans le sélecteur d'*entités* ni l'onglet Historique ; pour une carte qui demande une entité, utiliser le capteur `…_index_compteur_precis`.

## Tests

- Nouveau garde-fou : `test_import_creates_statistics` vérifie `metadata["unit_class"] == "volume"`.
- Local : ruff, ruff format, mypy strict, `pytest test_api.py` (45 passed).

Refs #29.
