### PR TITLE
ci: enforce architecture, dead code, duplication, complexity and dependency hygiene

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,27 @@ jobs:
       - name: Format check
         run: python -m ruff format --check custom_components/ tests/
 
+  quality:
+    name: Code quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Install quality tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_quality.txt
+      - name: Architecture (import-linter)
+        run: lint-imports
+      - name: Dependency hygiene (deptry)
+        run: python -m deptry custom_components/eaux_marseille
+      - name: Dead code (vulture)
+        run: python -m vulture
+      - name: Duplication (pylint)
+        run: python -m pylint custom_components/eaux_marseille --disable=all --enable=duplicate-code --score=n
+
   typecheck:
     name: Typecheck (mypy strict)
     runs-on: ubuntu-latest

--- a/custom_components/eaux_marseille/__init__.py
+++ b/custom_components/eaux_marseille/__init__.py
@@ -7,13 +7,14 @@ from datetime import timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STARTED, Platform
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 
+from ._client_factory import build_client
 from .api import EauxDeMarseilleClient
-from .const import CONF_CONTRACT_ID, CONF_PROVIDER, DEFAULT_PROVIDER, DOMAIN, Provider
+from .const import CONF_CONTRACT_ID, DOMAIN
 from .coordinator import EauxDeMarseilleCoordinator
 from .services import async_register_services
 from .statistics import async_import_historical_statistics
@@ -59,14 +60,7 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: EauxDeMarseilleConfigEntry) -> bool:
     """Set up Eaux de Marseille from a config entry."""
-    # Entries created before 1.9.0 don't store the provider; default to SEM.
-    provider = Provider(entry.data.get(CONF_PROVIDER, DEFAULT_PROVIDER.value))
-    client = EauxDeMarseilleClient(
-        login=entry.data[CONF_USERNAME],
-        password=entry.data[CONF_PASSWORD],
-        contract_id=entry.data[CONF_CONTRACT_ID],
-        provider=provider,
-    )
+    client = build_client(entry)
 
     coordinator = EauxDeMarseilleCoordinator(hass, client)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/eaux_marseille/_client_factory.py
+++ b/custom_components/eaux_marseille/_client_factory.py
@@ -1,0 +1,32 @@
+"""Build an API client from a config entry.
+
+Shared by :func:`async_setup_entry` and the ``reimport_statistics``
+service so the config-entry -> client mapping lives in exactly one place.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from .api import EauxDeMarseilleClient
+from .const import CONF_CONTRACT_ID, CONF_PROVIDER, DEFAULT_PROVIDER, Provider
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+
+
+def build_client(entry: ConfigEntry) -> EauxDeMarseilleClient:
+    """Construct an :class:`EauxDeMarseilleClient` from a config entry.
+
+    Entries created before 1.9.0 don't store the provider, so it defaults
+    to SEM (see :data:`DEFAULT_PROVIDER`).
+    """
+    provider = Provider(entry.data.get(CONF_PROVIDER, DEFAULT_PROVIDER.value))
+    return EauxDeMarseilleClient(
+        login=entry.data[CONF_USERNAME],
+        password=entry.data[CONF_PASSWORD],
+        contract_id=entry.data[CONF_CONTRACT_ID],
+        provider=provider,
+    )

--- a/custom_components/eaux_marseille/services.py
+++ b/custom_components/eaux_marseille/services.py
@@ -20,12 +20,11 @@ from typing import TYPE_CHECKING
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
 
-from .api import EauxDeMarseilleClient
-from .const import CONF_CONTRACT_ID, CONF_PROVIDER, DEFAULT_PROVIDER, DOMAIN, Provider
+from ._client_factory import build_client
+from .const import CONF_CONTRACT_ID, DOMAIN
 from .statistics import async_import_historical_statistics
 
 if TYPE_CHECKING:
@@ -81,13 +80,7 @@ def async_register_services(hass: HomeAssistant) -> None:
         # Use a fresh client so we don't disturb the coordinator's cached
         # session — re-importing a few years of history fires several
         # GETs and we don't want them to interleave with a regular poll.
-        provider = Provider(entry.data.get(CONF_PROVIDER, DEFAULT_PROVIDER.value))
-        client = EauxDeMarseilleClient(
-            login=entry.data[CONF_USERNAME],
-            password=entry.data[CONF_PASSWORD],
-            contract_id=entry.data[CONF_CONTRACT_ID],
-            provider=provider,
-        )
+        client = build_client(entry)
         try:
             await async_import_historical_statistics(hass, client, entry.data[CONF_CONTRACT_ID])
         finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+# A minimal PEP 621 table. This project is a Home Assistant custom
+# component, not a pip-installable package — the real version and runtime
+# requirements live in custom_components/eaux_marseille/manifest.json.
+# This block exists so `deptry` has a declared-dependency source to check
+# imports against; keep `dependencies` in sync with the manifest.
+[project]
+name = "eaux-marseille-ha"
+dynamic = ["version"]
+requires-python = ">=3.13"
+dependencies = ["tenacity>=8.0"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
@@ -39,6 +50,7 @@ select = [
     "PL",     # pylint
     "TRY",    # tryceratops (better try/except)
     "PERF",   # perflint
+    "C901",   # mccabe cyclomatic complexity
 ]
 ignore = [
     "E501",     # line-too-long (we use the formatter for that)
@@ -66,6 +78,11 @@ ignore = [
     "S106",     # hardcoded-password-func-arg (test fixtures use fake creds)
     "SLF001",   # private-member-access (tests inspect internals)
 ]
+
+[tool.ruff.lint.mccabe]
+# Cap cyclomatic complexity. The codebase currently sits well under this;
+# the gate keeps a single function from quietly growing unmanageable.
+max-complexity = 10
 
 [tool.ruff.lint.isort]
 known-first-party = ["custom_components.eaux_marseille"]
@@ -107,3 +124,76 @@ module = ["tests.*"]
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 disable_error_code = ["no-untyped-def", "type-arg", "no-untyped-call"]
+
+# ---------------------------------------------------------------------
+# import-linter: enforce the documented module architecture
+# ---------------------------------------------------------------------
+
+[tool.importlinter]
+root_package = "custom_components.eaux_marseille"
+
+[[tool.importlinter.contracts]]
+name = "Auth/transport stack stays layered (api -> _auth -> _http -> _redirects)"
+type = "layers"
+layers = [
+    "custom_components.eaux_marseille.api",
+    "custom_components.eaux_marseille._auth",
+    "custom_components.eaux_marseille._http",
+    "custom_components.eaux_marseille._redirects",
+]
+
+[[tool.importlinter.contracts]]
+name = "Leaf modules (const/exceptions/models) have no intra-package imports"
+type = "forbidden"
+source_modules = [
+    "custom_components.eaux_marseille.const",
+    "custom_components.eaux_marseille.exceptions",
+    "custom_components.eaux_marseille.models",
+]
+forbidden_modules = [
+    "custom_components.eaux_marseille.api",
+    "custom_components.eaux_marseille._auth",
+    "custom_components.eaux_marseille._http",
+    "custom_components.eaux_marseille._redirects",
+    "custom_components.eaux_marseille._client_factory",
+    "custom_components.eaux_marseille.coordinator",
+    "custom_components.eaux_marseille.config_flow",
+    "custom_components.eaux_marseille.sensor",
+    "custom_components.eaux_marseille.statistics",
+    "custom_components.eaux_marseille.diagnostics",
+    "custom_components.eaux_marseille.services",
+]
+
+# ---------------------------------------------------------------------
+# deptry: dependency hygiene (unused / missing / misplaced imports)
+# ---------------------------------------------------------------------
+
+[tool.deptry]
+# homeassistant, aiohttp, yarl and voluptuous are provided by the Home
+# Assistant runtime; HA integrations import them without declaring them as
+# requirements (manifest.json lists only tenacity). They are ignored
+# whether deptry classifies them as missing (DEP001, when HA isn't
+# installed in the run env) or transitive (DEP003, when it is). The
+# residual signal deptry still provides: tenacity must stay used (DEP002)
+# and no *other* undeclared third-party import may sneak in.
+[tool.deptry.per_rule_ignores]
+DEP001 = ["homeassistant", "aiohttp", "yarl", "voluptuous"]
+DEP003 = ["homeassistant", "aiohttp", "yarl", "voluptuous"]
+
+# ---------------------------------------------------------------------
+# Vulture: dead-code detection (see vulture_whitelist.py for the HA
+# framework hooks that are called by the framework, not by our code)
+# ---------------------------------------------------------------------
+
+[tool.vulture]
+paths = ["custom_components/eaux_marseille", "vulture_whitelist.py"]
+
+# ---------------------------------------------------------------------
+# Pylint: only the duplicate-code (copy/paste) checker is used; ruff
+# covers everything else.
+# ---------------------------------------------------------------------
+
+[tool.pylint.similarities]
+min-similarity-lines = 6
+ignore-imports = true
+ignore-signatures = true

--- a/requirements_quality.txt
+++ b/requirements_quality.txt
@@ -1,0 +1,7 @@
+# Static-analysis tools for the "Code quality" CI job. Kept separate from
+# requirements_test.txt because none of them need Home Assistant installed
+# (all are AST/graph based), so the job stays fast.
+import-linter==2.11
+deptry==0.25.1
+vulture==2.16
+pylint==4.0.6

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -30,10 +30,11 @@ def _full_client_mock(mock_client: MagicMock):
 
     The config flow validates credentials with one client, but on
     ``CREATE_ENTRY`` / reauth-reload Home Assistant immediately calls
-    ``async_setup_entry`` which imports the client from ``.api`` via
-    ``__init__``. Without patching that second path the real client
-    runs and opens a real socket — pytest-homeassistant-custom-component
-    fails the test on socket access since 0.13.317.
+    ``async_setup_entry`` which builds the client via
+    ``_client_factory.build_client``. Without patching that second path
+    the real client runs and opens a real socket —
+    pytest-homeassistant-custom-component fails the test on socket access
+    since 0.13.317.
 
     The coordinator's update method and the statistics importer are
     patched alongside so the post-create setup is fully offline.
@@ -44,7 +45,7 @@ def _full_client_mock(mock_client: MagicMock):
             return_value=mock_client,
         ),
         patch(
-            "custom_components.eaux_marseille.EauxDeMarseilleClient",
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
             return_value=mock_client,
         ),
         patch(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,7 +24,7 @@ async def test_setup_entry(hass: HomeAssistant, mock_client: MagicMock, mock_con
     """Integration sets up correctly from a config entry."""
     with (
         patch(
-            "custom_components.eaux_marseille.EauxDeMarseilleClient",
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
             return_value=mock_client,
         ),
         patch(
@@ -48,7 +48,7 @@ async def test_unload_entry(hass: HomeAssistant, mock_client: MagicMock, mock_co
     """Integration unloads correctly."""
     with (
         patch(
-            "custom_components.eaux_marseille.EauxDeMarseilleClient",
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
             return_value=mock_client,
         ),
         patch(
@@ -81,7 +81,7 @@ async def test_statistics_reimported_daily(
     mock_import = AsyncMock()
     with (
         patch(
-            "custom_components.eaux_marseille.EauxDeMarseilleClient",
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
             return_value=mock_client,
         ),
         patch(
@@ -117,7 +117,7 @@ async def test_daily_reimport_timer_cancelled_on_unload(
     mock_import = AsyncMock()
     with (
         patch(
-            "custom_components.eaux_marseille.EauxDeMarseilleClient",
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
             return_value=mock_client,
         ),
         patch(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -22,7 +22,7 @@ async def test_sensors_created(
     """All expected sensors are created on setup."""
     with (
         patch(
-            "custom_components.eaux_marseille.EauxDeMarseilleClient",
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
             return_value=mock_client,
         ),
         patch(
@@ -65,7 +65,7 @@ async def test_sensor_values(
     """Sensor states reflect the consumption data."""
     with (
         patch(
-            "custom_components.eaux_marseille.EauxDeMarseilleClient",
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
             return_value=mock_client,
         ),
         patch(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -28,7 +28,7 @@ async def _setup_loaded_entry(hass: HomeAssistant, mock_client: MagicMock, entry
     """Bring the integration up to ``LOADED`` for the given mock entry."""
     with (
         patch(
-            "custom_components.eaux_marseille.EauxDeMarseilleClient",
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
             return_value=mock_client,
         ),
         patch(
@@ -89,7 +89,7 @@ async def test_reimport_runs_historical_import(
     fresh_client.close = AsyncMock()
     with (
         patch(
-            "custom_components.eaux_marseille.services.EauxDeMarseilleClient",
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
             return_value=fresh_client,
         ),
         patch(

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,0 +1,27 @@
+# Vulture whitelist.
+#
+# These names look "unused" to vulture because they are called by the Home
+# Assistant framework (config-entry lifecycle hooks, the config-flow steps,
+# the coordinator update method, the sensor platform entry point, entity
+# attributes/properties), not by our own code. Listing them here marks them
+# as used so vulture only reports genuinely dead code.
+#
+# Regenerate with:  vulture custom_components/eaux_marseille --make-whitelist
+
+CONFIG_SCHEMA  # __init__.py
+async_setup  # __init__.py
+config  # __init__.py
+async_setup_entry  # __init__.py / sensor.py
+async_unload_entry  # __init__.py
+EauxDeMarseilleConfigFlow  # config_flow.py
+VERSION  # config_flow.py
+_.async_step_user  # config_flow.py
+_.async_step_reauth  # config_flow.py
+entry_data  # config_flow.py
+_.async_step_reconfigure  # config_flow.py
+_._async_update_data  # coordinator.py
+async_get_config_entry_diagnostics  # diagnostics.py
+PARALLEL_UPDATES  # sensor.py
+_._attr_unique_id  # sensor.py
+_._attr_device_info  # sensor.py
+_.native_value  # sensor.py


### PR DESCRIPTION
## Objectif

Renforcer la CI avec des analyses statiques de qualité. Note : `fallow` (l'outil initialement envisagé) cible **TypeScript/JavaScript** et ne s'applique pas à ce projet 100 % Python — on utilise donc les **équivalents Python natifs**.

## Nouveau job CI « Code quality »

Quatre analyseurs + un gate de complexité ruff. Tous sont AST/graphe, donc le job **n'installe pas Home Assistant** et reste rapide.

| Outil | Rôle | Config |
|---|---|---|
| **import-linter** | Encode l'architecture documentée en contrats : la pile `api → _auth → _http → _redirects` reste en couches, et `const`/`exceptions`/`models` restent des modules feuilles sans import interne. | `[tool.importlinter]` |
| **deptry** | Hygiène des dépendances. Nécessite une source de deps déclarées → un `[project]` PEP 621 minimal miroir le seul requirement runtime (`tenacity`) ; `homeassistant`/`aiohttp`/`yarl`/`voluptuous` sont fournis par HA et ignorés. | `[tool.deptry]` |
| **vulture** | Détection de code mort, avec `vulture_whitelist.py` listant les hooks framework HA (appelés par HA, pas par notre code). | `[tool.vulture]` |
| **pylint** (duplicate-code uniquement) | Détection de copier/coller ; ruff couvre le reste. | `[tool.pylint.similarities]` |
| **ruff `C901`** | Complexité cyclomatique (mccabe), max 10. | `[tool.ruff.lint.mccabe]` |

## Trouvaille réelle corrigée

Le check de duplication a immédiatement trouvé un vrai doublon : le bloc « construire un client depuis un config entry » était copié entre `async_setup_entry` et le service `reimport_statistics`. Extrait dans **`_client_factory.build_client`** (source unique). Les deux appelants et les tests qui patchent la construction du client passent désormais par ce module.

## Validation locale

ruff (+C901), ruff format, mypy strict, vulture, deptry, pylint-dupes, import-linter (2 contrats KEPT), pytest (48 passed / 30 skipped HA-only) — tout vert.
