### PR TITLE
fix: re-import statistics as soon as a newer reading arrives

### DIFF
--- a/custom_components/eaux_marseille/__init__.py
+++ b/custom_components/eaux_marseille/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 
@@ -82,10 +82,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: EauxDeMarseilleConfigEnt
     else:
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _run_import)
 
-    # Re-run the import daily so fresh contracts pick up their statistic
-    # once the portal starts serving data, and mature contracts get the
-    # new month on the Energy dashboard without a restart. The unsub is
-    # registered with the entry so the timer is cancelled on unload.
+    # Refresh the statistics as soon as the coordinator sees a newer
+    # reading, instead of waiting up to a day for the safety-net timer
+    # below. The precise meter index advances whenever the portal delivers
+    # new consumption (daily for communicating meters, ~monthly otherwise),
+    # so it is a good "fresh data" marker. Seeded from the first refresh —
+    # which the setup import above already covers — so we only fire on a
+    # genuine advance (#41).
+    last_imported_index = coordinator.data.index_precise_m3
+
+    @callback
+    def _reimport_on_new_data() -> None:
+        nonlocal last_imported_index
+        index = coordinator.data.index_precise_m3
+        if index is None or index == last_imported_index:
+            return
+        last_imported_index = index
+        hass.async_create_task(_run_import())
+
+    entry.async_on_unload(coordinator.async_add_listener(_reimport_on_new_data))
+
+    # Daily safety net: re-run even when the index didn't move, so revised
+    # past months still land and a fresh contract picks up its statistic
+    # once the portal starts serving data — all without a restart. The
+    # unsub is registered with the entry so the timer is cancelled on unload.
     entry.async_on_unload(async_track_time_interval(hass, _run_import, _STATS_REIMPORT_INTERVAL))
 
     return True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,7 @@ These tests require a full Home Assistant environment and only run in CI.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -108,6 +109,49 @@ async def test_statistics_reimported_daily(
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=2, minutes=2))
         await hass.async_block_till_done()
         assert mock_import.await_count == 3
+
+
+async def test_statistics_reimported_on_new_data(
+    hass: HomeAssistant, mock_client: MagicMock, mock_config_entry
+) -> None:
+    """Statistics re-import as soon as the coordinator sees a newer index (#41).
+
+    The precise meter index advances when the portal delivers new
+    consumption, so the import should follow immediately instead of
+    waiting for the daily timer. An unchanged index must not trigger a
+    redundant import.
+    """
+    mock_import = AsyncMock()
+    with (
+        patch(
+            "custom_components.eaux_marseille._client_factory.EauxDeMarseilleClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "custom_components.eaux_marseille.coordinator.EauxDeMarseilleCoordinator._async_update_data",
+            return_value=MOCK_CONSUMPTION,
+        ),
+        patch(
+            "custom_components.eaux_marseille.async_import_historical_statistics",
+            new=mock_import,
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert mock_import.await_count == 1  # one import at setup
+
+        coordinator = mock_config_entry.runtime_data.coordinator
+
+        # Same index on the next poll -> no redundant import.
+        coordinator.async_set_updated_data(MOCK_CONSUMPTION)
+        await hass.async_block_till_done()
+        assert mock_import.await_count == 1
+
+        # A fresher reading -> an immediate re-import.
+        fresher = replace(MOCK_CONSUMPTION, index_precise_m3=999.0)
+        coordinator.async_set_updated_data(fresher)
+        await hass.async_block_till_done()
+        assert mock_import.await_count == 2
 
 
 async def test_daily_reimport_timer_cancelled_on_unload(


### PR DESCRIPTION
Closes #41.

## Problème

Remonté par un utilisateur Vivaigo (compteur communicant, remontées irrégulières) : quand le portail livre plusieurs jours d'un coup, le **capteur d'index précis se met à jour tout de suite** (il suit le poll horaire du coordinator), mais les **statistiques traînent** — elles ne se ré-importaient que sur le timer quotidien (ou au setup / via un ré-import manuel). Il a dû relancer un ré-import à la main pour rattraper.

## Correctif

Un listener sur le coordinator relance l'import dès que l'**index précis avance** au-delà de la dernière valeur importée — un bon marqueur de « nouvelle donnée » (quotidien pour les compteurs communicants, ~mensuel sinon). Initialisé depuis le premier refresh (déjà couvert par l'import de setup) pour ne se déclencher que sur une vraie avancée. Le timer quotidien reste en filet de sécurité (historique révisé qui ne bouge pas l'index).

## Tests

- `test_statistics_reimported_on_new_data` : index inchangé → pas de ré-import ; index plus récent → ré-import immédiat.
- Local : ruff, ruff format, mypy strict, import-linter (2 contrats KEPT). Les tests `test_init` (HA-only) tournent en CI.

## Validation terrain

Testeur idéal : l'utilisateur Vivaigo (les rafales de données journalières irrégulières sont pile la condition de déclenchement) — à confirmer après release.
