### PR TITLE
chore: bump version to 1.16.4

### DIFF
--- a/custom_components/eaux_marseille/manifest.json
+++ b/custom_components/eaux_marseille/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.eaux_marseille"],
   "quality_scale": "gold",
   "requirements": ["tenacity>=8.0"],
-  "version": "1.16.3"
+  "version": "1.16.4"
 }


### PR DESCRIPTION
Release v1.16.4. Carries the user-facing fix #42 (statistics refresh as soon as a newer reading arrives) plus the internal CI/quality tooling and the `_client_factory` refactor accumulated since v1.16.3.